### PR TITLE
Fix hodor_dev.c

### DIFF
--- a/src/hodor_dev.c
+++ b/src/hodor_dev.c
@@ -17,7 +17,7 @@ static ssize_t hodor_read(struct file * file, char * buf,
 	if (*ppos != 0)
 		return 0;
 	
-	if (copy_to_user(buf, hodor_str, len))
+	if (raw_copy_to_user(buf, hodor_str, len))
 		return -EINVAL;
 	
 	*ppos = len;


### PR DESCRIPTION
I actually don't speak C, but the compiler told me that this needs to be changed and it does work...
```make -C /lib/modules/4.19.0-4-amd64/build M=/home/jonathan/dev-hodor-master/src modules
make[1]: Verzeichnis „/usr/src/linux-headers-4.19.0-4-amd64“ wird betreten
  CC [M]  /home/jonathan/dev-hodor-master/src/hodor_dev.o
/home/jonathan/dev-hodor-master/src/hodor_dev.c: In function ‘hodor_read’:
/home/jonathan/dev-hodor-master/src/hodor_dev.c:20:6: error: implicit declaration of function ‘copy_to_user’; did you mean ‘raw_copy_to_user’? [-Werror=implicit-function-declaration]
  if (copy_to_user(buf, hodor_str, len))
      ^~~~~~~~~~~~
      raw_copy_to_user
cc1: some warnings being treated as errors
make[4]: *** [/usr/src/linux-headers-4.19.0-4-common/scripts/Makefile.build:315: /home/jonathan/dev-hodor-master/src/hodor_dev.o] Fehler 1
make[3]: *** [/usr/src/linux-headers-4.19.0-4-common/Makefile:1535: _module_/home/jonathan/dev-hodor-master/src] Fehler 2
make[2]: *** [Makefile:146: sub-make] Fehler 2
make[1]: *** [Makefile:8: all] Fehler 2
make[1]: Verzeichnis „/usr/src/linux-headers-4.19.0-4-amd64“ wird verlassen
make: *** [Makefile:7: default] Fehler 2```